### PR TITLE
Add a new mechanic of handling the re-request of permissions

### DIFF
--- a/Source/Permission/Dialog/SPPermissionDialogController.swift
+++ b/Source/Permission/Dialog/SPPermissionDialogController.swift
@@ -104,15 +104,17 @@ public class SPPermissionDialogController: UIViewController {
             }
         }
         
-        if let permission = permission {
-            SPPermission.request(permission, with: {
-                if SPPermission.isAllow(permission) {
-                    self.delegate?.didAllow?(permission: permission)
+        guard let realPermission = permission else { return }
+        
+        if  SPPermission.isFirstTime(realPermission) { //it's the first time user press the "allow" button
+            SPPermission.request(realPermission, with: {
+                if SPPermission.isAllow(realPermission) {
+                    self.delegate?.didAllow?(permission: realPermission)
                     permissionView?.updateStyle()
                     for permission in self.permissions {
                         if SPPermission.isAllow(permission) {
                             if self.permissions.last == permission {
-                                SPPermissionStyle.Delay.wait(0.2, closure: {
+                                delay(0.2, closure: {
                                     self.hide(withDialog: true)
                                 })
                             }
@@ -122,6 +124,10 @@ public class SPPermissionDialogController: UIViewController {
                     }
                 }
             })
+        } else if !SPPermission.isAllow(realPermission) { //user has denied the request before, so this time just goto the app settings
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
         }
     }
     

--- a/Source/Permission/Dialog/SPPermissionDialogController.swift
+++ b/Source/Permission/Dialog/SPPermissionDialogController.swift
@@ -114,7 +114,7 @@ public class SPPermissionDialogController: UIViewController {
                     for permission in self.permissions {
                         if SPPermission.isAllow(permission) {
                             if self.permissions.last == permission {
-                                delay(0.2, closure: {
+                                SPPermissionStyle.Delay.wait(0.2, closure: {
                                     self.hide(withDialog: true)
                                 })
                             }

--- a/Source/Permission/SPPermission.swift
+++ b/Source/Permission/SPPermission.swift
@@ -31,6 +31,11 @@ import MediaPlayer
 
 public struct SPPermission {
     
+    public static func isFirstTime(_ permission: SPPermissionType) -> Bool {
+        let manager = self.getManagerForPermission(permission)
+        return manager.isFirstTime()
+    }
+    
     public static func isAllow(_ permission: SPPermissionType) -> Bool {
         let manager = self.getManagerForPermission(permission)
         return manager.isAuthorized()
@@ -49,6 +54,8 @@ public struct SPPermission {
 fileprivate protocol SPPermissionInterface {
     
     func isAuthorized() -> Bool
+    
+    func isFirstTime() -> Bool
     
     func request(withComlectionHandler complectionHandler: @escaping ()->()?)
 }
@@ -89,6 +96,10 @@ extension SPPermission {
     
     fileprivate struct SPCameraPermission: SPPermissionInterface {
         
+        func isFirstTime() -> Bool {
+            return AVCaptureDevice.authorizationStatus(for: AVMediaType.video) == .notDetermined
+        }
+        
         func isAuthorized() -> Bool {
             if AVCaptureDevice.authorizationStatus(for: AVMediaType.video) == AVAuthorizationStatus.authorized {
                 return true
@@ -108,6 +119,10 @@ extension SPPermission {
     }
     
     fileprivate struct SPNotificationPermission: SPPermissionInterface {
+        
+        func isFirstTime() -> Bool {
+            return !UIApplication.shared.isRegisteredForRemoteNotifications
+        }
         
         func isAuthorized() -> Bool {
             return UIApplication.shared.isRegisteredForRemoteNotifications
@@ -134,6 +149,10 @@ extension SPPermission {
     
     fileprivate struct SPPhotoLibraryPermission: SPPermissionInterface {
         
+        func isFirstTime() -> Bool {
+            return PHPhotoLibrary.authorizationStatus() == PHAuthorizationStatus.notDetermined
+        }
+        
         func isAuthorized() -> Bool {
             if PHPhotoLibrary.authorizationStatus() == PHAuthorizationStatus.authorized {
                 return true
@@ -154,6 +173,10 @@ extension SPPermission {
     
     fileprivate struct SPMicrophonePermission: SPPermissionInterface {
         
+        func isFirstTime() -> Bool {
+            return AVAudioSession.sharedInstance().recordPermission == .undetermined
+        }
+        
         func isAuthorized() -> Bool {
             if AVAudioSession.sharedInstance().recordPermission == .granted {
                 return true
@@ -173,6 +196,10 @@ extension SPPermission {
     
     
     fileprivate struct SPCalendarPermission: SPPermissionInterface {
+        
+        func isFirstTime() -> Bool {
+            return EKEventStore.authorizationStatus(for: EKEntityType.event) == .notDetermined
+        }
         
         func isAuthorized() -> Bool {
             let status = EKEventStore.authorizationStatus(for: EKEntityType.event)
@@ -196,6 +223,14 @@ extension SPPermission {
     }
     
     fileprivate struct SPContactsPermission: SPPermissionInterface {
+        
+        func isFirstTime() -> Bool {
+            if #available(iOS 9.0, *) {
+                return CNContactStore.authorizationStatus(for: .contacts) == .notDetermined
+            } else {
+                return ABAddressBookGetAuthorizationStatus() == .notDetermined
+            }
+        }
         
         func isAuthorized() -> Bool {
             if #available(iOS 9.0, *) {
@@ -238,6 +273,10 @@ extension SPPermission {
     
     fileprivate struct SPRemindersPermission: SPPermissionInterface {
         
+        func isFirstTime() -> Bool {
+            return EKEventStore.authorizationStatus(for: EKEntityType.reminder) == .notDetermined
+        }
+        
         func isAuthorized() -> Bool {
             let status = EKEventStore.authorizationStatus(for: EKEntityType.reminder)
             switch (status) {
@@ -260,6 +299,10 @@ extension SPPermission {
     }
     
     fileprivate struct SPBluetoothPermission: SPPermissionInterface {
+        
+        func isFirstTime() -> Bool {
+            return EKEventStore.authorizationStatus(for: EKEntityType.reminder) == .notDetermined
+        }
         
         func isAuthorized() -> Bool {
             let status = EKEventStore.authorizationStatus(for: EKEntityType.reminder)
@@ -284,6 +327,13 @@ extension SPPermission {
     
     fileprivate struct SPSpeechPermission: SPPermissionInterface {
         
+        func isFirstTime() -> Bool {
+            guard #available(iOS 10.0, *) else {
+                fatalError("ios 10 or higher required")
+            }
+            return SFSpeechRecognizer.authorizationStatus() == .notDetermined
+        }
+        
         func isAuthorized() -> Bool {
             guard #available(iOS 10.0, *) else { return false }
             return SFSpeechRecognizer.authorizationStatus() == .authorized
@@ -304,6 +354,10 @@ extension SPPermission {
     
     fileprivate struct SPMediaLibraryPermission: SPPermissionInterface {
         
+        func isFirstTime() -> Bool {
+            return MPMediaLibrary.authorizationStatus() == .notDetermined
+        }
+        
         func isAuthorized() -> Bool {
             let status = MPMediaLibrary.authorizationStatus()
             if status == .authorized {
@@ -323,6 +377,10 @@ extension SPPermission {
     }
     
     fileprivate struct SPLocationPermission: SPPermissionInterface {
+        
+        func isFirstTime() -> Bool {
+            return  CLLocationManager.authorizationStatus() == .notDetermined
+        }
         
         var type: SPLocationType
         

--- a/Source/Permission/SPPermission.swift
+++ b/Source/Permission/SPPermission.swift
@@ -28,7 +28,6 @@ import EventKit
 import Contacts
 import Speech
 import MediaPlayer
-import HealthKit
 
 public struct SPPermission {
     


### PR DESCRIPTION
When the app request permissions for the first time and user granted the request, this module works like perfect. But when user denied the first request, this moduel just do nothing when user press the "allow" button. So I added a new mechanic to give user a second chance to edit the permissions of their app. 

It worked well in my app.