### PR TITLE
Update NSLocation Usage Keys & Obsolete Old

### DIFF
--- a/SPPermission.podspec
+++ b/SPPermission.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "SPPermission"
-  s.version       = "3.0"
+  s.version       = "3.0.1"
   s.summary       = "Simple request permissions with dialog alert"
   s.homepage      = "https://github.com/IvanVorobei/RequestPermission"
   s.source        = { :git => "https://github.com/IvanVorobei/RequestPermission.git", :tag => s.version }

--- a/Source/SPPermission/Dialog/Controllers/SPPermissionDialogController.swift
+++ b/Source/SPPermission/Dialog/Controllers/SPPermissionDialogController.swift
@@ -395,9 +395,9 @@ extension SPPermissionDialogController {
             return "Application can create new task"
         case .speech:
             return "Allow check you voice"
-        case .locationAlways:
-            return "App will can check your location"
-        case .locationWhenInUse:
+        case .locationAlways,
+             .locationWhenInUse,
+             .locationAlwaysAndWhenInUse:
             return "App will can check your location"
         case .motion:
             return "Allow reports motion and environment-related data"

--- a/Source/SPPermission/Dialog/Views/SPPermissionDialogView.swift
+++ b/Source/SPPermission/Dialog/Views/SPPermissionDialogView.swift
@@ -185,9 +185,9 @@ class SPPermissionDialogLineView: UIView {
                 self.iconView.type = .calendar
             case .speech:
                 self.iconView.type = .micro
-            case .locationWhenInUse:
-                self.iconView.type = .compass
-            case .locationAlways:
+            case .locationWhenInUse,
+                 .locationAlways,
+                 .locationAlwaysAndWhenInUse:
                 self.iconView.type = .compass
             case .motion:
                 self.iconView.type = .windmill

--- a/Source/SPPermission/SPPermission.swift
+++ b/Source/SPPermission/SPPermission.swift
@@ -92,6 +92,8 @@ extension SPPermission {
             return SPLocationPermission(type: SPLocationPermission.SPLocationType.Always)
         case .locationWhenInUse:
            return SPLocationPermission(type: SPLocationPermission.SPLocationType.WhenInUse)
+        case .locationAlwaysAndWhenInUse:
+            return SPLocationPermission(type: SPLocationPermission.SPLocationType.AlwaysAndWhenInUse)
         case .motion:
             return SPMotionPermission()
         case .mediaLibrary:
@@ -355,6 +357,7 @@ extension SPPermission {
         enum SPLocationType {
             case Always
             case WhenInUse
+            case AlwaysAndWhenInUse
         }
         
         init(type: SPLocationType) {
@@ -372,7 +375,7 @@ extension SPPermission {
                 } else {
                     return false
                 }
-            case .WhenInUse:
+            case .WhenInUse, .AlwaysAndWhenInUse:
                 if status == .authorizedAlways {
                     return true
                 } else {
@@ -392,7 +395,7 @@ extension SPPermission {
         func request(withComlectionHandler complectionHandler: @escaping ()->()?) {
             
             switch self.type {
-            case .Always:
+            case .Always, .AlwaysAndWhenInUse:
                 if SPPermissionAlwaysAuthorizationLocationHandler.shared == nil {
                     SPPermissionAlwaysAuthorizationLocationHandler.shared = SPPermissionAlwaysAuthorizationLocationHandler()
                 }

--- a/Source/SPPermission/SPPermissionType.swift
+++ b/Source/SPPermission/SPPermissionType.swift
@@ -31,10 +31,12 @@ import UIKit
     case contacts = 5
     case reminders = 6
     case speech = 7
+    @available(iOS, obsoleted: 11, renamed: "locationAlwaysAndWhenInUse")
     case locationAlways = 8
     case locationWhenInUse = 9
-    case motion = 10
-    case mediaLibrary = 11
+    case locationAlwaysAndWhenInUse = 10
+    case motion = 11
+    case mediaLibrary = 12
     
     var name: String {
         switch self {
@@ -57,6 +59,8 @@ import UIKit
         case .locationAlways:
             return "Location"
         case .locationWhenInUse:
+            return "Location"
+        case .locationAlwaysAndWhenInUse:
             return "Location"
         case .motion:
             return "Motion"
@@ -87,6 +91,8 @@ import UIKit
             return "NSLocationAlwaysUsageDescription"
         case .locationWhenInUse:
             return "NSLocationWhenInUseUsageDescription"
+        case .locationAlwaysAndWhenInUse:
+            return "NSLocationAlwaysAndWhenInUseUsageDescription"
         case .motion:
             return "NSMotionUsageDescription"
         case .mediaLibrary:


### PR DESCRIPTION
Fixes #89 
Updates with new `NSLocationAlwaysAndWhenInUseUsageDescription` key
Obsoletes old `NSLocationAlwaysUsageDescription` on iOS 11.0 and lower

Conforms to [Apple's CoreLocation documentation](https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_always_authorization)

A slightly different strategy was taken than the one suggested in the issue. Instead of using the `introduced` element (conflicts with building on iOS 10), use `obsoleted` and `renamed` instead