### PR TITLE
Update README to fix the list of Info.plist location permission strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,9 @@ SPPermission uses many permissions in one library; you need to add some strings 
 - NSAppleMusicUsageDescription
 - NSSpeechRecognitionUsageDescription
 - NSMotionUsageDescription
-- NSLocationAlwaysUsageDescription
 - NSLocationWhenInUseUsageDescription
+- NSLocationAlwaysAndWhenInUseUsageDescription
+- NSLocationAlwaysUsageDescription (iOS 10 and earlier)
 
 Do not use the description as the name of the key - this causes errors in the latest version of the new Xcode. Specify `For SPPermission` in the description.
 If I forgot to mention some, please let me know and create [issue](https://github.com/ivanvorobei/SPPermission/issues) or [pull request](https://github.com/ivanvorobei/SPPermission/pulls).


### PR DESCRIPTION
There seemed to be a mismatch between the location permission keys mentioned on Apple's docs and those in the README list, so I updated it. No big deal at all, but I thought having the correct list might save someone time later one.

From the [docs](https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_always_authorization):

> You are required to include the **NSLocationWhenInUseUsageDescription** and **NSLocationAlwaysAndWhenInUseUsageDescription** keys in your app's Info.plist file. (If your app supports iOS 10 and earlier, the **NSLocationAlwaysUsageDescription** key is also required.) If those keys are not present, authorization requests fail immediately. 

I added **NSLocationAlwaysAndWhenInUseUsageDescription** to the README list, and marked **NSLocationAlwaysUsageDescription** as optional (iOS 10 and earlier).

Hope this is correct!

Thank you so much for creating the library Ivan,
Kevin